### PR TITLE
Change how filter works to match our Java API

### DIFF
--- a/examples/flash-filter/FlashState.js
+++ b/examples/flash-filter/FlashState.js
@@ -1,0 +1,17 @@
+export default class FlashState {
+  constructor() {
+    this.state = {};
+  }
+
+  set(key, value) {
+    this.state[key] = value;
+  }
+
+  get(key) {
+    return this.state[key];
+  }
+
+  toString() {
+    return JSON.stringify(this.state);
+  }
+}

--- a/examples/flash-filter/HomePage.js
+++ b/examples/flash-filter/HomePage.js
@@ -1,0 +1,15 @@
+import { Page } from '../../src';
+import UseFlash from './UseFlash';
+
+export default class HomePage extends Page {
+  constructor() {
+    super(...arguments);
+
+    this.filters.push(UseFlash);
+  }
+
+  render(req, res, next) {
+    req.flash.set('message', 'register first');
+    return res.redirect('/register');
+  }
+}

--- a/examples/flash-filter/RegisterPage.js
+++ b/examples/flash-filter/RegisterPage.js
@@ -1,0 +1,16 @@
+import { Page } from '../../src';
+import UseFlash from './UseFlash';
+
+export default class RegisterPage extends Page {
+  constructor() {
+    super(...arguments);
+
+    this.filters.push(UseFlash);
+  }
+
+  render(req, res, next) {
+    const { flashContent } = req;
+    const message = flashContent['message'] || 'register here';
+    return this.send(req, next, message);
+  }
+}

--- a/examples/flash-filter/UseFlash.js
+++ b/examples/flash-filter/UseFlash.js
@@ -1,0 +1,34 @@
+import { Filter } from '../../src';
+import cookieParser from 'cookie';
+import FlashState from './FlashState';
+
+const FLASH_COOKIE_NAME = '__flash';
+
+const sessionCookieSettings = {
+  path: '/',
+  domain: 'localhost'
+};
+
+export default class UseFlash extends Filter {
+  onRequest(req, res, next) {
+    let flashContent;
+    const cookie = cookieParser.parse(req.headers.cookie || '');
+
+    try {
+      flashContent = JSON.parse(cookie[FLASH_COOKIE_NAME]);
+    }
+    catch (err) {
+      flashContent = {};
+    }
+
+    req.flashContent = flashContent;
+    req.flash = new FlashState();
+    next();
+  }
+
+  onResponse(req, res, next) {
+    const { flash } = req;
+    res.cookie(FLASH_COOKIE_NAME, flash.toString(), sessionCookieSettings);
+    next();
+  }
+}

--- a/examples/flash-filter/index.js
+++ b/examples/flash-filter/index.js
@@ -1,0 +1,2 @@
+require('babel-core/register');
+require('./server');

--- a/examples/flash-filter/server.js
+++ b/examples/flash-filter/server.js
@@ -1,0 +1,13 @@
+import { PathPrefixRouter as Router } from '../../src';
+import HomePage from './HomePage.js';
+import RegisterPage from './RegisterPage';
+
+const router = new Router('localhost', ['en', 'id-id', 'en-id', 'en-sg'], 'id-id');
+router.register('localhost', ['en', 'id-id', 'en-id', 'en-sg'], 'id-id', route => {
+  route('HOME', 'get', 'http', '/', HomePage);
+  route('REGISTER', 'get', 'http', '/register', RegisterPage);
+});
+
+router.start(3000, () => {
+  console.log('Started at port 3000');
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "./node_modules/.bin/babel src --out-dir lib",
+    "build": "babel src --out-dir lib",
     "prepublish": "npm run build"
   },
   "repository": {
@@ -30,10 +30,22 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "babel": "^5.8.21",
     "body-parser": "^1.13.3",
     "express": "^4.13.3",
     "immutable": "^3.7.4",
     "path-to-regexp": "^1.2.1"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.9.0",
+    "babel-core": "^6.9.1",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-1": "^6.5.0",
+    "cookie": "^0.3.1"
+  },
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-1"
+    ]
   }
 }

--- a/src/core/Filter.js
+++ b/src/core/Filter.js
@@ -1,5 +1,9 @@
 class Filter {
-  onFilter(req, res, next) {
+  onRequest(req, res, next) {
+    next();
+  }
+
+  onResponse(req, res, next) {
     next();
   }
 }

--- a/src/core/Page.js
+++ b/src/core/Page.js
@@ -1,7 +1,7 @@
-import Sender from '../filters/Sender';
-
 class Page {
   constructor(routeId, requestType, protocols, route, domains) {
+    this.filters = [];
+
     this._routeId = routeId;
     this._requestType = requestType;
     this._protocols = protocols;
@@ -11,12 +11,6 @@ class Page {
     protocols.forEach(p => {
       this._protocolMap[p] = true;
     });
-    this._initDefaultFilters();
-  }
-
-  _initDefaultFilters() {
-    this._requestFilters = [];
-    this._responseFilters = [Sender];
   }
 
   getDomain(locale, protocol) {
@@ -36,14 +30,6 @@ class Page {
 
   getRoute() {
     return this._route;
-  }
-
-  getRequestFilters() {
-    return this._requestFilters;
-  }
-
-  getResponseFilters() {
-    return this._responseFilters;
   }
 
   render(req, res, next) {

--- a/src/core/asInterceptor.js
+++ b/src/core/asInterceptor.js
@@ -1,0 +1,20 @@
+/**
+ * Given an express middleware, convert them into an interceptor,
+ * which will only run just before request will be sent to client
+ */
+export default function asInterceptor(fn) {
+  const interceptor = function (req, res, next) {
+    const originalEnd = res.end;
+
+    res.end = function end (chunk, encoding) {
+      const args = Array.prototype.slice.call(arguments);
+      fn(req, res, () => {
+        originalEnd.apply(res, args);
+      });
+    };
+
+    next();
+  };
+
+  return interceptor;
+}

--- a/src/filters/Sender.js
+++ b/src/filters/Sender.js
@@ -1,9 +1,0 @@
-import Filter from '../core/Filter';
-
-class Sender extends Filter {
-  onFilter(req, res) {
-    res.send(req.responseBody);
-  }
-}
-
-export default Sender;


### PR DESCRIPTION
See `examples/flash-filter/UseFlash` for new API signature
- Use `onRequest` and `onResponse` instead of `onFilter`
- Remove `page._requestFilters` and `page._responseFilters`, use `page.filters` public property instead
- Monkey patch `res.end` to properly intercept the response and run `onResponse` filter
- Move Sender filter to last Router arguments
- Update babel 6
- Add optional callback to `router.start` to easily know when app is ready
