### PR TITLE
[FIX] Add support for localhost env with port

### DIFF
--- a/src/core/Router.js
+++ b/src/core/Router.js
@@ -84,7 +84,7 @@ class Router {
 
   start(port, opt_callback) {
     this._app.use((req, res, next) => {
-      const host = req.hostname;
+      const host = req.headers.host || req.hostname;
       if (this._routers.hasOwnProperty(host)) {
         this._routers[host](req, res, next);
       } else {


### PR DESCRIPTION
fix read host instead of hostname, this fix make request-transport can identify port for example (localhost:8000)