### PR TITLE
Return http.Server instance on Route.start()

### DIFF
--- a/src/core/Router.js
+++ b/src/core/Router.js
@@ -92,7 +92,7 @@ class Router {
         res.status(404).send();
       }
     });
-    this._app.listen(port, opt_callback);
+    return this._app.listen(port, opt_callback);
   }
 }
 


### PR DESCRIPTION
Express return http.Server instance when calling app.listen(). This object may be used for other purpose, for example to gracefully shutdown the app.